### PR TITLE
Fetch latest delivery date

### DIFF
--- a/lib/mws/orders/order.rb
+++ b/lib/mws/orders/order.rb
@@ -108,6 +108,10 @@ module MWS
       attribute(:latest_shipped_at) do
         time_at_xpath("LatestShipDate")
       end
+
+      attribute(:latest_delivery_date) do
+        time_at_xpath("LatestDeliveryDate")
+      end
     end
   end
 end

--- a/lib/mws/orders/order.rb
+++ b/lib/mws/orders/order.rb
@@ -110,7 +110,7 @@ module MWS
       end
 
       attribute(:latest_delivery_date) do
-        time_at_xpath("LatestDeliveryDate")
+        time_at_xpath('LatestDeliveryDate')
       end
     end
   end

--- a/test/fixtures/orders.xml
+++ b/test/fixtures/orders.xml
@@ -49,6 +49,8 @@
         <BuyerEmail>5vlh04mgfmjh9h5@marketplace.amazon.com</BuyerEmail>
         <ShipmentServiceLevelCategory>Standard
         </ShipmentServiceLevelCategory>
+        <LatestShipDate>2012-10-15T07:59:59Z</LatestShipDate>
+        <LatestDeliveryDate>2012-10-15T07:59:59Z</LatestDeliveryDate>
       </Order>
       <Order>
         <ShipmentServiceLevelCategory>Standard

--- a/test/fixtures/orders.xml
+++ b/test/fixtures/orders.xml
@@ -41,7 +41,7 @@
               <Amount>10.00</Amount>
             </Payment>
             <PaymentMethod>GC</PaymentMethod>
-          </PaymentExecutionDetailItem>  
+          </PaymentExecutionDetailItem>
         </PaymentExecutionDetail>
         <PaymentMethod>COD</PaymentMethod>
         <MarketplaceId>ATVPDKIKX0DER</MarketplaceId>
@@ -68,6 +68,7 @@
         <PurchaseDate>2012-10-11T14:15:55Z</PurchaseDate>
         <EarliestShipDate>2012-10-13T05:00:00Z</EarliestShipDate>
         <LatestShipDate>2012-10-15T07:59:59Z</LatestShipDate>
+        <LatestDeliveryDate>2012-10-15T07:59:59Z</LatestDeliveryDate>
         <OrderType>Preorder</OrderType>
         <NumberOfItemsUnshipped>0</NumberOfItemsUnshipped>
         <MarketplaceId>ATVPDKIKX0DER</MarketplaceId>

--- a/test/mws/orders/test_order.rb
+++ b/test/mws/orders/test_order.rb
@@ -82,4 +82,12 @@ class TestOrder < MiniTest::Test
     @order.xpath('ShippingAddress').remove
     assert_nil @order.shipping_address
   end
+
+  def test_latest_shipped_at
+    assert_kind_of Time, @order.latest_shipped_at
+  end
+
+  def test_latest_delivery_date
+    assert_kind_of Time, @order.latest_delivery_date
+  end
 end


### PR DESCRIPTION
USER STORY I.A.:  As an application manager, I want to record the latest_ship_date (timestamp) and latest_delivery_date on each sale so that we can fine-tune ship confirmations and post-sale follow up.

Available fields: http://docs.developer.amazonservices.com/en_UK/orders-2013-09-01/Orders_Datatypes.html#Order