### PR TITLE
Add headers to the parser

### DIFF
--- a/lib/mws/orders/parser.rb
+++ b/lib/mws/orders/parser.rb
@@ -8,6 +8,8 @@ require 'mws/orders/service_status'
 module MWS
   module Orders
     class Parser
+      include ::Peddler::Headers
+
       SERVICE_STATUS = /GetServiceStatus/
       ORDER          = /GetOrder/
       ORDERS         = /ListOrders/
@@ -32,6 +34,10 @@ module MWS
         else
           raise NotImplementedError
         end
+      end
+
+      def headers
+        @response.headers
       end
 
       private


### PR DESCRIPTION
When using peddler w/o this Gem we can access certain methods through:

`response.mws_response_context`

When we switch to using mws-orders, we're unable to do this. This PR gives us the same functionality as the default parser.