### PR TITLE
Expose status code and body of the response

### DIFF
--- a/lib/mws/orders/parser.rb
+++ b/lib/mws/orders/parser.rb
@@ -35,6 +35,14 @@ module MWS
         @response.headers
       end
 
+      def status_code
+        @response.status
+      end
+
+      def body
+        @response.body
+      end
+
       private
 
       def find_result_node


### PR DESCRIPTION
Expose status code and body of the response within the parser.

This is useful as otherwise to get this information we'd have to do:

`result.instance_variable_get(:@response).status`

Which is quite dirty.

In my particular case I need access to this information as I like to log all API requests/responses and query on them later.